### PR TITLE
Fix url format, add `:` after the protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix url format, add `:` after the protocol.
 
 ## [0.1.1] - 2019-09-02
 ### Fixed

--- a/react/SearchAction.tsx
+++ b/react/SearchAction.tsx
@@ -23,11 +23,11 @@ const SearchAction = () => {
   const hostname = canUseDOM ? window.location.hostname : global.__hostname__
   const rootPath = canUseDOM ? window.__RUNTIME__.rootPath : global.__RUNTIME__.rootPath
 
-  const baseUrl = `${protocol}//${hostname}${rootPath || ''}/`
+  const baseUrl = `${protocol}://${hostname}${rootPath || ''}/`
 
   const schema = {
     '@context': 'http://schema.org',
-    '@type': 'Website',
+    '@type': 'WebSite',
     url: baseUrl,
     potentialAction: {
       '@type': 'SearchAction',


### PR DESCRIPTION
 ### Fixed
- Added `:` after protocol in the URL.

Linked workspace:
https://camiloc--storecomponents.myvtex.com