### PR TITLE
Add @id property to Product structured data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,63 +7,95 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `@id` property to Product structured data so that multiple tags for the same product can be consolidated
+
 ## [0.6.1] - 2020-12-18
+
 ### Fixed
+
 - Remove `dangerouslySetInnerHTML`.
 
 ## [0.6.0] - 2020-10-22
+
 ### Added
+
 - `ProductList` component to render a product list structured data.
 
 ## [0.5.0] - 2020-08-04
+
 ### Added
+
 - `ProductBreadcrumb` component to render a product's breadcrumb structured data.
 - `SearchBreadcrumb` component to render a search's breadcrumb structured data.
 
 ## [0.4.0] - 2020-07-01
+
 ### Added
+
 - Use spot price as lowPrice.
 
 ## [0.3.2] - 2020-03-06
+
 ### Fixed
+
 - Product Structured Data being duplicated.
 
 ## [0.3.1] - 2020-03-06
+
 ### Fixed
+
 - Wrap Product's structured data into `react-helmet`.
 
 ## [0.3.0] - 2020-02-28
+
 ### Changed
+
 - Use prop `searchTermPath` to set the path of SearchAction.
 
 ## [0.2.1] - 2019-12-27
+
 ### Fixed
+
 - Use docs builder.
 
 ## [0.2.0] - 2019-10-22
+
 ### Added
+
 - Move code of Product Structured Data from `vtex.store` to this app.
 
 ### Fixed
+
 - Remove markup if the product is unavailable. We used to fill the price with zero, providing Google the wrong information.
 
 ## [0.1.2] - 2019-09-05
+
 ### Fixed
+
 - Fix url format, add `:` after the protocol.
 
 ## [0.1.1] - 2019-09-02
+
 ### Fixed
+
 - URLs with rootPath.
 
 ## [0.1.0] - 2019-09-02
+
 ### Changed
+
 - Name of the component to `SearchAction` to be more generic.
 
 ### Fixed
+
 - `potentialAction.target`.
 - Protocol in SSR.
 - Minify JSON.
 
 ## [0.0.2] - 2019-08-30
+
 ### Added
+
 - Add Component With Google Search Box Script.

--- a/react/Product.js
+++ b/react/Product.js
@@ -122,6 +122,7 @@ export const parseToJsonLD = (product, selectedItem, currency) => {
   const productLD = {
     '@context': 'https://schema.org/',
     '@type': 'Product',
+    '@id': product.link,
     name,
     brand,
     image: image && image.imageUrl,


### PR DESCRIPTION
**What problem is this solving?**

EcoWater has noticed that although they're using BazaarVoice for product reviews, and although the BazaarVoice app adds structured data for reviews to the PDP, Google is not displaying review data in search results:
![image (3)](https://user-images.githubusercontent.com/6306265/110839500-9ce37600-8271-11eb-888f-c5e67ed38d35.png)

Google's Rich Results test tool does show the review data, but note that it is treated as a second Product: https://search.google.com/test/rich-results?id=d2RMvFRAloRHZXBOAml9kw

For displaying review data in search results, Google seems to only take into account the first Product listed in the rich results (even though they're the same product).

However! If we add an "@id" property to both LD+JSON tags (and any other tags for the same product, Google will consolidate them, as shown in this test: https://search.google.com/test/rich-results?id=aBhlwxTOAIlGqPM1JQG4gw

**How should this be manually tested?**

Workspace with the fix linked: https://arthur--ecowaterqa.myvtex.com/brita-under-sink-main-kitchen-bathroom-water-filter/p 