### PR TITLE
fixing product list structured data

### DIFF
--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -6,7 +6,7 @@ import { getBaseUrl } from './modules/baseUrl'
 
 interface Product {
   productName: string
-  linkText: string
+  link: string
 }
 
 interface Props {
@@ -24,7 +24,7 @@ export function getProductList(products?: Product[]) {
     '@type': 'ListItem',
     position: index + 1,
     name: product.productName,
-    url: `${baseUrl}/${product.linkText}`,
+    url: `${baseUrl}/${product.link}`,
   }))
 
   return {

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@vtex/tsconfig",
   "compilerOptions": {
+    "jsx": "react",
     "noEmitOnError": false,
     "typeRoots": ["node_modules/@types"],
     "types": ["node", "jest", "graphql"],


### PR DESCRIPTION
**What problem is this solving?**

the product list structured data component is not bringing the /p impacting the SEO performance of the sites. 
The previous URL returned to a 404

**How should this be manually tested?**
Go to this workspace https://cesar--itwhirlpool.myvtex.com/ 
scroll down to the first product shelf, inspect the element and verify that the structured data URL includes the /p

Example:
Live SIte URL: "url":"https://itwhirlpool.myvtex.com//asciugatrice-a-pompa-di-calore-whirlpool-a-libera-installazione-8-kg-ft-m11-8x3b-it-869991584020   --> sends to a 404
Workspace URL: "url":"https://cesar--itwhirlpool.myvtex.com//asciugatrice-a-pompa-di-calore-whirlpool-a-libera-installazione-8-kg-ft-m11-8x3b-it-869991584020/p --> link exists