### PR TITLE
fix: brand name as string

### DIFF
--- a/react/Product.js
+++ b/react/Product.js
@@ -136,8 +136,8 @@ const getCategoryName = (product) =>
 
 function parseBrand(brand) {
   return {
-    '@type': brand.type,
-    name: brand.name,
+    '@type': 'Brand',
+    name: typeof brand === 'string' ? brand : brand.name,
   }
 }
 


### PR DESCRIPTION
**What problem is this solving?**

Sometimes the brand data from the product is a string, but in another moment can be an object, so in order to solve this, this PR creates a condition to catch when the brand is a string or object.

**How should this be manually tested?**

**Screenshots or example usage:**