### PR TITLE
[USAAPPTEAM-706] Improve ProductList data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.8.1] - 2022-01-11
 ### Changed
+
+- Add full details of each product in `ProductList` component
+- Fall back to `product.description` if `product.metaTagDescription` is not present
+
+## [0.8.1] - 2022-01-11
+
+### Changed
+
 - Use product's URI as @id on `Product` schema.
 
 ## [0.8.0] - 2022-01-04
+
 ### Added
+
 - Added search parameter `?map=ft` to SearchAction's `potentialAction`
 
 ## [0.7.3] - 2022-01-03
@@ -28,11 +37,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - brand typo
 
 ## [0.7.1] - 2021-10-18
+
 ### Fixed
+
 - add the /p parameter to the productList structured data URL
 
 ## [0.7.0] - 2021-08-05
-### Added 
+
+### Added
+
 - `settingsSchema` to allow stores to send `pricesWithTax` and specify the number of `decimals`
 
 ## [0.6.2] - 2021-03-11

--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,8 @@
   "vendor": "vtex",
   "name": "structured-data",
   "version": "0.8.1",
-  "title": "Structure data",
-  "description": "Structure data",
+  "title": "Structured data",
+  "description": "Structured data",
   "defaultLocale": "pt-BR",
   "builders": {
     "react": "3.x",
@@ -23,16 +23,16 @@
     "type": "object",
     "properties": {
       "decimals": {
-        "title": "admin/application-settings.decimals.title",
+        "title": "Number of decimals",
         "type": "number",
         "default": 2,
-        "description": "admin/application-settings.decimals.description"
+        "description": "Set the number of decimals you want the prices to show"
       },
       "pricesWithTax": {
-        "title": "admin/application-settings.prices-with-tax.title",
+        "title": "Prices with tax",
         "type": "boolean",
         "default": false,
-        "description": "admin/application-settings.prices-with-tax.description"
+        "description": "Add tax to the price shown on Google"
       }
     }
   },

--- a/react/Product.d.ts
+++ b/react/Product.d.ts
@@ -1,0 +1,50 @@
+export function parseToJsonLD({
+  product,
+  selectedItem,
+  currency,
+  decimals,
+  pricesWithTax,
+}: {
+  product: any
+  selectedItem: any
+  currency: any
+  decimals: any
+  pricesWithTax: any
+}): {
+  '@context': string
+  '@type': string
+  '@id': string
+  name: any
+  brand: {
+    '@type': string
+    name: any
+  }
+  image: any
+  description: any
+  mpn: any
+  sku: any
+  category: any
+  offers: {
+    '@type': string
+    lowPrice: any
+    highPrice: any
+    priceCurrency: any
+    offers: any
+    offerCount: any
+  }
+}
+declare const _default: import('react').MemoExoticComponent<typeof StructuredData>
+export default _default
+declare function StructuredData({
+  product,
+  selectedItem,
+}: {
+  product: any
+  selectedItem: any
+}): JSX.Element
+declare namespace StructuredData {
+  namespace propTypes {
+    const product: any
+    const selectedItem: any
+  }
+}

--- a/react/Product.js
+++ b/react/Product.js
@@ -171,7 +171,7 @@ export const parseToJsonLD = ({
     name,
     brand: parseBrand(brand),
     image: image && image.imageUrl,
-    description: product.metaTagDescription,
+    description: product.metaTagDescription || product.description,
     mpn: product.productId,
     sku: selectedItem.itemId,
     category: getCategoryName(product),

--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -1,33 +1,51 @@
 import React from 'react'
 import { jsonLdScriptProps } from 'react-schemaorg'
 import { ItemList, WithContext, ListItem } from 'schema-dts'
+import { useRuntime } from 'vtex.render-runtime'
 
-import { getBaseUrl } from './modules/baseUrl'
+import useAppSettings from './hooks/useAppSettings'
+import { parseToJsonLD } from './Product'
 
 interface Product {
   productName: string
   linkText: string
   link: string
+  items: any[]
 }
 
 interface Props {
   products?: Product[]
 }
 
-export function getProductList(products?: Product[]) {
+export function getProductList({
+  decimals,
+  pricesWithTax,
+  currency,
+  products,
+}: {
+  decimals: number
+  pricesWithTax: boolean
+  currency: string
+  products?: Product[]
+}) {
   if (!Array.isArray(products)) {
     return null
   }
 
-  const baseUrl = getBaseUrl()
-
   const productItems: ListItem[] = products.map((product, index) => {
-    const productUrl = `${baseUrl}/${product.link ?? `${product.linkText}/p`}`
+    const [selectedItem] = product.items
+    const item = parseToJsonLD({
+      product,
+      selectedItem,
+      currency,
+      decimals,
+      pricesWithTax,
+    })
+
     return {
       '@type': 'ListItem',
       position: index + 1,
-      name: product.productName,
-      url: productUrl,
+      ...(item && { item }),
     }
   })
 
@@ -39,7 +57,17 @@ export function getProductList(products?: Product[]) {
 }
 
 function ProductList({ products }: Props) {
-  const productListLD: WithContext<ItemList> | null = getProductList(products)
+  const {
+    culture: { currency },
+  } = useRuntime()
+
+  const { decimals, pricesWithTax } = useAppSettings()
+  const productListLD: WithContext<ItemList> | null = getProductList({
+    decimals,
+    pricesWithTax,
+    currency,
+    products,
+  })
 
   if (!productListLD) {
     return null

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -9,5 +9,6 @@
     "moduleResolution": "node",
     "target": "es2017"
   },
-  "include": ["./typings/*.d.ts", "./**/*.tsx", "./**/*.ts"]
+  "include": ["./typings/*.d.ts", "./**/*.tsx", "./**/*.ts", "Product.tsx"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
**What problem is this solving?**

This is a request brought by Alfonso Suarez on behalf of client `budgetgolf` (see Slack thread [here](https://vtex.slack.com/archives/C01PRGM0WG1/p1656686408460439)).

To summarize, our clients' SEO for PLPs can be improved by including the full product details in the `ItemList` schema.org markup, which this PR implements.

**How should this be manually tested?**

I linked the new version of this app in https://arthur--budgetgolf.myvtex.com and https://arthur--eriksbikeshop.myvtex.com and ran some tests using the Google Rich Results tool:

Budget Golf: https://search.google.com/test/rich-results/result/r%2Fproduct?id=ql0gisWux8w6p4egwUCRRQ

Erik's Bikes: https://search.google.com/test/rich-results/result/r%2Fproduct?id=FtPJr64Vqs-GGx-SK5XQAw
