### PR TITLE
Fix: Handle null/undefined seller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Handle `null` seller in `parseSKUToOffer()`
+
 ## [0.9.0] - 2022-07-08
 
 ### Changed

--- a/react/Product.js
+++ b/react/Product.js
@@ -85,7 +85,7 @@ const parseSKUToOffer = (item, currency, { decimals, pricesWithTax }) => {
     priceValidUntil: path(['commertialOffer', 'PriceValidUntil'], seller),
     seller: {
       '@type': 'Organization',
-      name: seller.sellerName,
+      name: seller ? seller.sellerName : '',
     },
   }
 


### PR DESCRIPTION
**What problem is this solving?**

Previous version threw an error on the https://storecomponents.myvtex.com homepage, "Cannot read properties of undefined (reading 'sellerName')"

This PR adds handling in case the seller object is null or undefined.

**How should this be manually tested?**

New version linked here: https://structureddata--storecomponents.myvtex.com/