### PR TITLE
feat: add pricesHidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `settingsSchema` to allow stores to send `pricesHidden` and specify if prices should be send
+
 ## [0.9.1] - 2022-07-08
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -33,6 +33,12 @@
         "type": "boolean",
         "default": false,
         "description": "Add tax to the price shown on Google"
+      },
+      "pricesHidden": {
+        "title": "Prices Hidden",
+        "type": "boolean",
+        "default": false,
+        "description": "Hide prices shown on Google"
       }
     }
   },

--- a/messages/context.json
+++ b/messages/context.json
@@ -1,6 +1,8 @@
 {
   "admin/application-settings.decimals.title": "Number of decimals",
   "admin/application-settings.prices-with-tax.title": "Prices with tax",
+  "admin/application-settings.prices-hidden.title": "Prices Hidden",
   "admin/application-settings.decimals.description": "Set the number of decimals you want the prices to show",
-  "admin/application-settings.prices-with-tax.description": "Add tax to the price shown on Google"
+  "admin/application-settings.prices-with-tax.description": "Add tax to the price shown on Google",
+  "admin/application-settings.prices-hidden.description": "Hide prices shown on Google"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,6 +1,8 @@
 {
   "admin/application-settings.decimals.title": "Number of decimals",
   "admin/application-settings.prices-with-tax.title": "Prices with tax",
+  "admin/application-settings.prices-hidden.title": "Prices Hidden",
   "admin/application-settings.decimals.description": "Set the number of decimals you want the prices to show",
-  "admin/application-settings.prices-with-tax.description": "Add tax to the price shown on Google"
+  "admin/application-settings.prices-with-tax.description": "Add tax to the price shown on Google",
+  "admin/application-settings.prices-hidden.description": "Hide prices shown on Google"
 }

--- a/react/Product.d.ts
+++ b/react/Product.d.ts
@@ -4,12 +4,14 @@ export function parseToJsonLD({
   currency,
   decimals,
   pricesWithTax,
+  pricesHidden,
 }: {
   product: unknown
   selectedItem: unknown
   currency: string
   decimals: number
   pricesWithTax: boolean
+  pricesHidden: boolean
 }): {
   '@context': string
   '@type': string

--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -20,11 +20,13 @@ interface Props {
 export function getProductList({
   decimals,
   pricesWithTax,
+  pricesHidden,
   currency,
   products,
 }: {
   decimals: number
   pricesWithTax: boolean
+  pricesHidden: boolean
   currency: string
   products?: Product[]
 }) {
@@ -40,6 +42,7 @@ export function getProductList({
       currency,
       decimals,
       pricesWithTax,
+      pricesHidden,
     })
 
     return {
@@ -61,10 +64,11 @@ function ProductList({ products }: Props) {
     culture: { currency },
   } = useRuntime()
 
-  const { decimals, pricesWithTax } = useAppSettings()
+  const { decimals, pricesWithTax, pricesHidden } = useAppSettings()
   const productListLD: WithContext<ItemList> | null = getProductList({
     decimals,
     pricesWithTax,
+    pricesHidden,
     currency,
     products,
   })

--- a/react/__tests__/useAppSettings.test.jsx
+++ b/react/__tests__/useAppSettings.test.jsx
@@ -12,7 +12,7 @@ const mockQueryData = {
   result: {
     data: {
       appSettings: {
-        message: '{"decimals": 2, "pricesWithTax": true}',
+        message: '{"decimals": 2, "pricesWithTax": true, "pricesHidden": true}',
       },
     },
   },
@@ -25,7 +25,8 @@ const mockQueryDataNull = {
   result: {
     data: {
       appSettings: {
-        message: '{"decimals": null, "pricesWithTax": null}',
+        message:
+          '{"decimals": null, "pricesWithTax": null, "pricesHidden": null}',
       },
     },
   },
@@ -52,6 +53,7 @@ test('should return object', async () => {
 
   expect(result.current.decimals).toBe(2)
   expect(result.current.pricesWithTax).toBe(true)
+  expect(result.current.pricesHidden).toBe(true)
 })
 
 test('should return default object', async () => {
@@ -61,4 +63,5 @@ test('should return default object', async () => {
 
   expect(result.current.decimals).toBe(2)
   expect(result.current.pricesWithTax).toBe(false)
+  expect(result.current.pricesHidden).toBe(false)
 })

--- a/react/hooks/useAppSettings.ts
+++ b/react/hooks/useAppSettings.ts
@@ -5,31 +5,38 @@ import GET_SETTINGS from '../queries/getSettings.graphql'
 
 const DEFAULT_DECIMALS = 2
 const DEFAULT_PRICES_WITH_TAX = false
+const DEFAULT_PRICES_HIDDEN = false
 
 interface Settings {
   decimals: number
   pricesWithTax: boolean
+  pricesHidden: boolean
 }
 
 const useAppSettings = (): Settings => {
   const [settings, setSettings] = useState<Settings>({
     decimals: DEFAULT_DECIMALS,
     pricesWithTax: DEFAULT_PRICES_WITH_TAX,
+    pricesHidden: DEFAULT_PRICES_HIDDEN,
   })
 
   const { data, loading } = useQuery(GET_SETTINGS, { ssr: false })
 
   useEffect(() => {
     if (!loading && data?.appSettings?.message) {
-      const { decimals, pricesWithTax } = JSON.parse(data.appSettings.message)
+      const { decimals, pricesWithTax, pricesHidden } = JSON.parse(
+        data.appSettings.message
+      )
 
       if (
         decimals !== undefined &&
         decimals !== null &&
         pricesWithTax !== null &&
-        pricesWithTax !== undefined
+        pricesWithTax !== undefined &&
+        pricesHidden !== null &&
+        pricesHidden !== undefined
       ) {
-        setSettings({ decimals, pricesWithTax })
+        setSettings({ decimals, pricesWithTax, pricesHidden })
       }
     }
   }, [loading, data])

--- a/react/package.json
+++ b/react/package.json
@@ -27,9 +27,9 @@
     "graphql": "^14.6.0",
     "schema-dts": "^0.8.2",
     "typescript": "3.9.7",
-    "vtex.apps-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@2.8.0/public/@types/vtex.apps-graphql",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime",
-    "vtex.structured-data": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.7.1/public/@types/vtex.structured-data"
+    "vtex.apps-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@2.9.0/public/@types/vtex.apps-graphql",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
+    "vtex.structured-data": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.9.1/public/@types/vtex.structured-data"
   },
   "version": "0.9.1"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5517,17 +5517,17 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.apps-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@2.8.0/public/@types/vtex.apps-graphql":
-  version "2.8.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@2.8.0/public/@types/vtex.apps-graphql#4fd47b1281c4d36e8abb1cfa4daea83bc739eca1"
+"vtex.apps-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@2.9.0/public/@types/vtex.apps-graphql":
+  version "2.9.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@2.9.0/public/@types/vtex.apps-graphql#731e03bfeb51b498a7ed139bd71e3169ee1cb598"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime":
-  version "8.132.3"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime#c7dd142e384f38bd7a7c841543b73e9349fadc93"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime":
+  version "8.132.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
 
-"vtex.structured-data@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.7.1/public/@types/vtex.structured-data":
-  version "0.7.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.7.1/public/@types/vtex.structured-data#ef3dfc28f5e8e993dd2583ee859608794a72f947"
+"vtex.structured-data@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.9.1/public/@types/vtex.structured-data":
+  version "0.9.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.9.1/public/@types/vtex.structured-data#6f612c921c5df19c2f065082448dd24a91fcc9b4"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
**What problem is this solving?**

This PR aims to add an option to hide product prices from Google and potencially others search engines, so that closed and partially closed stores (where the user must be logged in to see prices, for example) avoid price leakings.

**How should this be manually tested?**

A configuration, Prices Hidden, was created in the app's settings, see image below, which can be tested in the following workspace: https://featpriceshidden--acctglobal.myvtex.com/admin/apps/vtex.structured-data@0.9.1/setup/

By default the Prices Hidden value is set to false to not impact any store that's currently using this app.

**Screenshots or example usage:**

To test the default value (false):

![structured-data-prices-hidden-off](https://user-images.githubusercontent.com/115560420/210617817-4d3b1e1a-4ffe-4b33-8528-4d6a340e5d2f.png)

- access a product, category or other page that has products (shelfs) https://featpriceshidden--acctglobal.myvtex.com/camiseta-acct/p;
- open the devtools, in the elements tab do a search for "ld+json", open the script corresponding to the product or product list and check the prices;

![PricesHiddenOFF-pdp](https://user-images.githubusercontent.com/115560420/210618989-f6cda415-5fc5-4f4b-9296-9c6632787ad1.png)

To test Prices Hidden (true):

![structured-data-prices-hidden-on](https://user-images.githubusercontent.com/115560420/210619556-3bcacd4b-344e-411a-a1bf-7aa65920f841.png)

- access a product, category or other page that has products (shelfs) https://featpriceshidden--acctglobal.myvtex.com/camiseta-acct/p;
- open the devtools, in the elements tab do a search for "ld+json", open the script corresponding to the product or product list and check the prices;

![PricesHiddenON-pdp](https://user-images.githubusercontent.com/115560420/210620222-d26362a2-4472-4df8-a842-18d15683d601.png)