### PR TITLE
feat: add disableOffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add new `settingsSchema` option `disableOffers` to fill `offers` as null when enabled
+
 ## [0.10.0] - 2023-02-15
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -23,6 +23,12 @@
     "type": "object",
     "access": "public",
     "properties": {
+      "disableOffers": {
+        "title": "Disable Offers",
+        "type": "boolean",
+        "default": false,
+        "description": "Disable product offers shown on Google"
+      },
       "decimals": {
         "title": "Number of decimals",
         "type": "number",

--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,7 @@
         "title": "Disable Offers",
         "type": "boolean",
         "default": false,
-        "description": "Disable product offers shown on Google"
+        "description": "Disable product offers"
       },
       "decimals": {
         "title": "Number of decimals",

--- a/react/Product.d.ts
+++ b/react/Product.d.ts
@@ -2,12 +2,14 @@ export function parseToJsonLD({
   product,
   selectedItem,
   currency,
+  disableOffers,
   decimals,
   pricesWithTax,
 }: {
   product: unknown
   selectedItem: unknown
   currency: string
+  disableOffers: boolean
   decimals: number
   pricesWithTax: boolean
 }): {

--- a/react/Product.js
+++ b/react/Product.js
@@ -146,6 +146,7 @@ export const parseToJsonLD = ({
   product,
   selectedItem,
   currency,
+  disableOffers,
   decimals,
   pricesWithTax,
 }) => {
@@ -175,7 +176,7 @@ export const parseToJsonLD = ({
     mpn: product.productId,
     sku: selectedItem && selectedItem.itemId,
     category: getCategoryName(product),
-    offers,
+    offers: disableOffers ? null : offers,
   }
 
   return productLD
@@ -186,12 +187,13 @@ function StructuredData({ product, selectedItem }) {
     culture: { currency },
   } = useRuntime()
 
-  const { decimals, pricesWithTax } = useAppSettings()
+  const { disableOffers, decimals, pricesWithTax } = useAppSettings()
 
   const productLD = parseToJsonLD({
     product,
     selectedItem,
     currency,
+    disableOffers,
     decimals,
     pricesWithTax,
   })

--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -18,11 +18,13 @@ interface Props {
 }
 
 export function getProductList({
+  disableOffers,
   decimals,
   pricesWithTax,
   currency,
   products,
 }: {
+  disableOffers: boolean
   decimals: number
   pricesWithTax: boolean
   currency: string
@@ -38,6 +40,7 @@ export function getProductList({
       product,
       selectedItem,
       currency,
+      disableOffers,
       decimals,
       pricesWithTax,
     })
@@ -61,8 +64,9 @@ function ProductList({ products }: Props) {
     culture: { currency },
   } = useRuntime()
 
-  const { decimals, pricesWithTax } = useAppSettings()
+  const { disableOffers, decimals, pricesWithTax } = useAppSettings()
   const productListLD: WithContext<ItemList> | null = getProductList({
+    disableOffers,
     decimals,
     pricesWithTax,
     currency,

--- a/react/__tests__/Product.test.js
+++ b/react/__tests__/Product.test.js
@@ -5,6 +5,7 @@ import { createProduct, createItem } from '../__fixtures__/productMock'
 import { product as mktPlaceProduct } from '../__fixtures__/marketplaceProductMock'
 import * as getBaseUrl from '../modules/baseUrl'
 
+let mockDisableOffers = false
 let mockDecimals = 2
 let mockPricesWithTax = false
 let mockGetBaseUrl
@@ -28,6 +29,7 @@ describe('Product Structured Data', () => {
     const cheapItem = createItem({ id: '2', price: 45, quantity: 1 })
     const expensiveItem = createItem({ id: '3', price: 60, quantity: 2 })
 
+    mockDisableOffers = false
     mockDecimals = 2
     mockPricesWithTax = false
 
@@ -38,6 +40,7 @@ describe('Product Structured Data', () => {
       product,
       selectedItem: product.items[0],
       currency,
+      disableOffers: mockDisableOffers,
       decimals: mockDecimals,
       pricesWithTax: mockPricesWithTax,
     })
@@ -60,6 +63,7 @@ describe('Product Structured Data', () => {
 
     product.items.push(cheapItem)
 
+    mockDisableOffers = false
     mockDecimals = 2
     mockPricesWithTax = false
 
@@ -67,6 +71,7 @@ describe('Product Structured Data', () => {
       product,
       selectedItem: product.items[0],
       currency,
+      disableOffers: mockDisableOffers,
       decimals: mockDecimals,
       pricesWithTax: mockPricesWithTax,
     })
@@ -83,6 +88,7 @@ describe('Product Structured Data', () => {
     product.items.push(unavailableItem)
     product.items.push(availableItem)
 
+    mockDisableOffers = false
     mockDecimals = 2
     mockPricesWithTax = false
 
@@ -90,6 +96,7 @@ describe('Product Structured Data', () => {
       product,
       selectedItem: product.items[0],
       currency,
+      disableOffers: mockDisableOffers,
       decimals: mockDecimals,
       pricesWithTax: mockPricesWithTax,
     })
@@ -114,6 +121,7 @@ describe('Product Structured Data', () => {
     productTwoSkus.items.push(unavailableItem)
     productTwoSkus.items.push(unavailableItem)
 
+    mockDisableOffers = false
     mockDecimals = 2
     mockPricesWithTax = false
 
@@ -121,6 +129,7 @@ describe('Product Structured Data', () => {
       product: productOneSku,
       selectedItem: productOneSku.items[0],
       currency,
+      disableOffers: mockDisableOffers,
       decimals: mockDecimals,
       pricesWithTax: mockPricesWithTax,
     })
@@ -129,6 +138,7 @@ describe('Product Structured Data', () => {
       product: productTwoSkus,
       selectedItem: productTwoSkus.items[0],
       currency,
+      disableOffers: mockDisableOffers,
       decimals: mockDecimals,
       pricesWithTax: mockPricesWithTax,
     })
@@ -138,6 +148,7 @@ describe('Product Structured Data', () => {
   })
 
   it('should handle multiple sellers correctly, get correct low price and high price', () => {
+    mockDisableOffers = false
     mockDecimals = 2
     mockPricesWithTax = false
 
@@ -145,6 +156,7 @@ describe('Product Structured Data', () => {
       product: mktPlaceProduct,
       selectedItem: mktPlaceProduct.items[0],
       currency,
+      disableOffers: mockDisableOffers,
       decimals: mockDecimals,
       pricesWithTax: mockPricesWithTax,
     })
@@ -163,6 +175,7 @@ describe('Product Structured Data', () => {
     item.sellers[2].commertialOffer.spotPrice = 1000
     copyProduct.items.push(item)
 
+    mockDisableOffers = false
     mockDecimals = 2
     mockPricesWithTax = false
 
@@ -170,6 +183,7 @@ describe('Product Structured Data', () => {
       product: copyProduct,
       selectedItem: copyProduct.items[0],
       currency,
+      disableOffers: mockDisableOffers,
       decimals: mockDecimals,
       pricesWithTax: mockPricesWithTax,
     })
@@ -190,6 +204,7 @@ describe('Product Structured Data', () => {
     item.sellers[2].commertialOffer.spotPrice = 1000
     copyProduct.items.push(item)
 
+    mockDisableOffers = false
     mockDecimals = 2
     mockPricesWithTax = true
 
@@ -197,6 +212,7 @@ describe('Product Structured Data', () => {
       product: copyProduct,
       selectedItem: copyProduct.items[0],
       currency,
+      disableOffers: mockDisableOffers,
       decimals: mockDecimals,
       pricesWithTax: mockPricesWithTax,
     })
@@ -220,5 +236,24 @@ describe('Product Structured Data', () => {
     })
 
     expect(result['@id']).toBe(`${mockedBaseUrl}/${copyProduct.linkText}/p`)
+  })
+
+  it('should not fill offers if disableOffers is true', () => {
+    const copyProduct = clone(mktPlaceProduct)
+
+    mockDisableOffers = true
+    mockDecimals = 2
+    mockPricesWithTax = false
+
+    const result = parseToJsonLD({
+      product: copyProduct,
+      selectedItem: copyProduct.items[0],
+      currency,
+      disableOffers: mockDisableOffers,
+      decimals: mockDecimals,
+      pricesWithTax: mockPricesWithTax,
+    })
+
+    expect(result.offers).toBeNull()
   })
 })

--- a/react/__tests__/ProductList.test.js
+++ b/react/__tests__/ProductList.test.js
@@ -1,6 +1,7 @@
 import { getProductList } from '../ProductList'
 import { createProductList } from '../__fixtures__/productListMock'
 
+const disableOffers = false
 const decimals = 2
 const pricesWithTax = false
 const currency = 'USD'
@@ -17,6 +18,7 @@ describe('Product List Structured Data', () => {
     const productListLD = getProductList({
       products,
       decimals,
+      disableOffers,
       pricesWithTax,
       currency,
     })
@@ -118,6 +120,7 @@ describe('Product List Structured Data', () => {
     const productListLD = getProductList({
       products,
       decimals,
+      disableOffers,
       pricesWithTax,
       currency,
     })
@@ -130,10 +133,27 @@ describe('Product List Structured Data', () => {
     const productListLD = getProductList({
       products,
       decimals,
+      disableOffers,
       pricesWithTax,
       currency,
     })
 
     expect(productListLD).toBeNull()
+  })
+
+  it('should not fill offers if disableOffers is true', () => {
+    const products = createProductList()
+
+    const productListLD = getProductList({
+      products,
+      decimals,
+      disableOffers: true,
+      pricesWithTax,
+      currency,
+    })
+
+    expect(productListLD['@type']).toBe('ItemList')
+    expect(productListLD.itemListElement).toHaveLength(2)
+    expect(productListLD.itemListElement[0].item.offers).toBeNull()
   })
 })

--- a/react/__tests__/useAppSettings.test.jsx
+++ b/react/__tests__/useAppSettings.test.jsx
@@ -12,7 +12,8 @@ const mockQueryData = {
   result: {
     data: {
       publicSettingsForApp: {
-        message: '{"decimals": 4, "pricesWithTax": true}',
+        message:
+          '{"disableOffers": false, "decimals": 4, "pricesWithTax": true}',
       },
     },
   },
@@ -25,7 +26,8 @@ const mockQueryDataNull = {
   result: {
     data: {
       publicSettingsForApp: {
-        message: '{"decimals": null, "pricesWithTax": null}',
+        message:
+          '{"disableOffers": null, "decimals": null, "pricesWithTax": null}',
       },
     },
   },
@@ -50,6 +52,7 @@ test('should return object', async () => {
 
   await waitForNextUpdate()
 
+  expect(result.current.disableOffers).toBe(false)
   expect(result.current.decimals).toBe(4)
   expect(result.current.pricesWithTax).toBe(true)
 })
@@ -59,6 +62,7 @@ test('should return default object', async () => {
 
   await waitForNextUpdate()
 
+  expect(result.current.disableOffers).toBe(false)
   expect(result.current.decimals).toBe(2)
   expect(result.current.pricesWithTax).toBe(false)
 })

--- a/react/hooks/useAppSettings.ts
+++ b/react/hooks/useAppSettings.ts
@@ -2,10 +2,12 @@ import { useQuery } from 'react-apollo'
 
 import GET_SETTINGS from '../queries/getSettings.graphql'
 
+const DEFAULT_DISABLE_OFFERS = false
 const DEFAULT_DECIMALS = 2
 const DEFAULT_PRICES_WITH_TAX = false
 
 interface Settings {
+  disableOffers: boolean
   decimals: number
   pricesWithTax: boolean
 }
@@ -14,17 +16,19 @@ const useAppSettings = (): Settings => {
   const { data } = useQuery(GET_SETTINGS, { ssr: false })
 
   if (data?.publicSettingsForApp?.message) {
-    const { decimals, pricesWithTax } = JSON.parse(
+    const { disableOffers, decimals, pricesWithTax } = JSON.parse(
       data.publicSettingsForApp.message
     )
 
     return {
+      disableOffers: disableOffers || DEFAULT_DISABLE_OFFERS,
       decimals: decimals || DEFAULT_DECIMALS,
       pricesWithTax: pricesWithTax || DEFAULT_PRICES_WITH_TAX,
     }
   }
 
   return {
+    disableOffers: DEFAULT_DISABLE_OFFERS,
     decimals: DEFAULT_DECIMALS,
     pricesWithTax: DEFAULT_PRICES_WITH_TAX,
   }

--- a/react/package.json
+++ b/react/package.json
@@ -27,8 +27,9 @@
     "graphql": "^14.6.0",
     "schema-dts": "^0.8.2",
     "typescript": "3.9.7",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime",
-    "vtex.structured-data": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.7.1/public/@types/vtex.structured-data"
+    "vtex.apps-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@3.14.1/public/@types/vtex.apps-graphql",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime",
+    "vtex.structured-data": "https://disableoffers--acctglobal.myvtex.com/_v/private/typings/linked/v1/vtex.structured-data@0.10.0+build1678125175/public/@types/vtex.structured-data"
   },
   "version": "0.10.0"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5517,13 +5517,17 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime":
-  version "8.132.3"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime#c7dd142e384f38bd7a7c841543b73e9349fadc93"
+"vtex.apps-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@3.14.1/public/@types/vtex.apps-graphql":
+  version "3.14.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@3.14.1/public/@types/vtex.apps-graphql#955c2c5a8d5316ec7c50849acbbd2d245894b8dc"
 
-"vtex.structured-data@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.7.1/public/@types/vtex.structured-data":
-  version "0.7.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.7.1/public/@types/vtex.structured-data#ef3dfc28f5e8e993dd2583ee859608794a72f947"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime":
+  version "8.132.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.4/public/@types/vtex.render-runtime#66bb41bd4d342e37c9d85172aad5f7eefebfb6dc"
+
+"vtex.structured-data@https://disableoffers--acctglobal.myvtex.com/_v/private/typings/linked/v1/vtex.structured-data@0.10.0+build1678125175/public/@types/vtex.structured-data":
+  version "0.10.0"
+  resolved "https://disableoffers--acctglobal.myvtex.com/_v/private/typings/linked/v1/vtex.structured-data@0.10.0+build1678125175/public/@types/vtex.structured-data#45183a84c757068afaf792c6767b309e2c1ee4a0"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
**What problem is this solving?**

Currently, closed and partially closed stores (where the user must login to see prices, for instance) leak the prices throught the field `offers`, present at the "Product" structured data. Once `vtex.structured-data` is implemented right into the `store` builder, which cannot be customized, this behavior can't be disabled. Therefore, with this PR, we implement a new `settingsSchema` option, `disableOffers`,  to expose this possibility.  

**How should this be manually tested?**

In what follows, consider this workspace: https://disableoffers--acctglobal.myvtex.com/

1. Enable the option `disableOffers`.

<img width="1552" alt="Screenshot 2023-03-08 at 14 49 52" src="https://user-images.githubusercontent.com/115579881/223790874-b91be3d0-6bc5-4b34-9941-d6f2e15d3bd1.png">

2. Access a PDP and check that the product structured data does not contain the `offers` field.

<img width="1552" alt="Screenshot 2023-03-08 at 14 48 49" src="https://user-images.githubusercontent.com/115579881/223790644-40c05571-6061-48b2-b90a-faae42536067.png">

3. Check that the structured data highlight above validates against the schema.org validator (https://validator.schema.org) without erros or warnings.

<img width="1552" alt="Screenshot 2023-03-08 at 14 51 58" src="https://user-images.githubusercontent.com/115579881/223791474-6497f1df-ce21-46bd-8e2b-feb81cf9b627.png">

4. Repeat the steps above at PLP's and pages with shelfs: any page where a product is in place.

Remark that, at code level, the new option `disableOffers` is off by default once it hits production -- meaning this is a minor new feature: no breaking changes. 