### PR TITLE
fix : additional control on products in the GetProductList function

### DIFF
--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -30,7 +30,7 @@ export function getProductList({
   currency: string
   products?: Product[]
 }) {
-  if (!Array.isArray(products)) {
+  if (!Array.isArray(products) || products?.length === 0) {
     return null
   }
 


### PR DESCRIPTION
**What problem is this solving?**
The structured data of the breadcrumbs is being pushed with 'itemListElement' as an empty array.
The goal should be to remove the breadcrumbs structered data when the PLP doesn't return any product. 

![checkInsideGPLfunction](https://github.com/vtex-apps/structured-data/assets/169069829/f0340eb6-337e-49c9-beb8-d1296a4731cf)

I added a simple check on the products, I inserted it into the getProductList function. and linked it to this workspace 
https://mobv2587525--itwhirlpool.myvtex.com/prodotti/aria-condizionata/deumidificatori
with this solution within my workspace, the structured data of breadcrumbs is no longer pushed if there are no products.


Here the referent Vtex ticket : #1017354 

A
[Structured Data Errors.xlsx](https://github.com/vtex-apps/structured-data/files/15331205/Structured.Data.Errors.xlsx)
Attached you can find the error reports provided to me by the SEO team.
