### PR TITLE
 Fixed : Google Search Console: Breadcrumb structured data issues in Custom PLP pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed breadcrumb structured data issue in PLP where this field is missing `itemsListElement`.
+
 ## [0.12.0] - 2023-05-10
 
 ### Added

--- a/react/SearchBreadcrumb.tsx
+++ b/react/SearchBreadcrumb.tsx
@@ -11,7 +11,7 @@ interface SearchBreadcrumbItem {
 }
 
 const getSearchBreadcrumb = (breadcrumb?: SearchBreadcrumbItem[]) => {
-  if (!Array.isArray(breadcrumb)) {
+  if (!Array.isArray(breadcrumb) || breadcrumb?.length === 0) {
     return {}
   }
 


### PR DESCRIPTION
**What problem is this solving?**

Example Url where this issue can be seen: https://www.worldwidegolfshops.com/shoes/mens-spiked-golf-shoes

We received a report that some custom search template pages have a breadcrumb structured data issue where this field is missing “itemsListElement”. 

![image (45)](https://github.com/vtex-apps/structured-data/assets/106958993/f13155db-fac1-4230-8816-493adcd09c83)

When we inspect in the browser, the additional structured data is present only in the 'View Source' & not in 'HTML elements'.

![image-20240510-022541](https://github.com/vtex-apps/structured-data/assets/106958993/251ad732-213e-47a5-809f-670fb4353465)
![image](https://github.com/vtex-apps/structured-data/assets/106958993/4bfceee7-ed5b-477b-b950-46e1d5eb6f94)

I added a simple check on the breadcrumbs . I inserted it into the getSearchBreadcrumb function and linked it to this workspace
https://wt568b2--worldwidegolf.myvtex.com/
with this solution within my workspace, the structured data of breadcrumbs is no longer pushed if there are no breadcrumb in the array.
