### PR TITLE
Add productRefId to productSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Fixed
+### Changed
 - **Product Schema** for **Reference Number**, `mpn` now uses item reference identification.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- **Product Schema** for **Reference Number**, `mpn` now uses item reference identification.
+
+### Added
+- `GTIN` when `EAN` is available
+
 ## [0.12.1] - 2024-06-17
 
 ### Fixed

--- a/react/.eslintrc
+++ b/react/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "vtex-react/io"
+  "extends": "vtex-react/io",
+  "parserOptions": {
+    "ecmaVersion": 2020
+  }
 }

--- a/react/Product.d.ts
+++ b/react/Product.d.ts
@@ -25,6 +25,7 @@ export function parseToJsonLD({
   }
   image: string
   description: string
+  gtin: string
   mpn: string
   sku: number
   category: string

--- a/react/Product.js
+++ b/react/Product.js
@@ -189,7 +189,6 @@ export const parseToJsonLD = ({
 
   const baseUrl = getBaseUrl()
 
-  // Category is derived from product categories array
   const category = getCategoryName(product)
 
   // Adding missing properties like GTIN, review, aggregateRating if available

--- a/react/Product.js
+++ b/react/Product.js
@@ -200,7 +200,7 @@ export const parseToJsonLD = ({
     brand: parseBrand(brand),
     image: image?.imageUrl || null,
     description: product.metaTagDescription || product.description,
-    mpn, // Updated mpn logic
+    mpn,
     sku: selectedItem?.itemId || null,
     category,
     offers: disableOffers ? null : offers,

--- a/react/Product.js
+++ b/react/Product.js
@@ -171,7 +171,6 @@ export const parseToJsonLD = ({
   const { brand } = product
   const name = product.productName
 
-  // Ensure that mpn uses the correct fallback logic
   const mpn =
     selectedItem?.referenceId?.[0]?.Value ||
     product?.productReference ||

--- a/react/Product.js
+++ b/react/Product.js
@@ -171,6 +171,12 @@ export const parseToJsonLD = ({
   const { brand } = product
   const name = product.productName
 
+  // Ensure that mpn uses the correct fallback logic
+  const mpn =
+    selectedItem?.referenceId?.[0]?.Value ||
+    product?.productReference ||
+    product?.productId
+
   const offers = composeAggregateOffer(product, currency, {
     decimals,
     pricesWithTax,
@@ -183,18 +189,25 @@ export const parseToJsonLD = ({
 
   const baseUrl = getBaseUrl()
 
+  // Category is derived from product categories array
+  const category = getCategoryName(product)
+
+  // Adding missing properties like GTIN, review, aggregateRating if available
+  const gtin = selectedItem?.ean || null
+
   const productLD = {
     '@context': 'https://schema.org/',
     '@type': 'Product',
     '@id': `${baseUrl}/${product.linkText}/p`,
     name,
     brand: parseBrand(brand),
-    image: image && image.imageUrl,
+    image: image?.imageUrl || null,
     description: product.metaTagDescription || product.description,
-    mpn: product.productId,
-    sku: selectedItem && selectedItem.itemId,
-    category: getCategoryName(product),
+    mpn, // Updated mpn logic
+    sku: selectedItem?.itemId || null,
+    category,
     offers: disableOffers ? null : offers,
+    gtin, // Add GTIN if available
   }
 
   return productLD

--- a/react/Product.js
+++ b/react/Product.js
@@ -204,7 +204,7 @@ export const parseToJsonLD = ({
     sku: selectedItem?.itemId || null,
     category,
     offers: disableOffers ? null : offers,
-    gtin, // Add GTIN if available
+    gtin,
   }
 
   return productLD

--- a/react/Product.js
+++ b/react/Product.js
@@ -190,7 +190,6 @@ export const parseToJsonLD = ({
 
   const category = getCategoryName(product)
 
-  // Adding missing properties like GTIN, review, aggregateRating if available
   const gtin = selectedItem?.ean || null
 
   const productLD = {

--- a/react/__tests__/ProductList.test.js
+++ b/react/__tests__/ProductList.test.js
@@ -40,6 +40,7 @@ describe('Product List Structured Data', () => {
           name: products[0].brand,
         },
         description: products[0].description,
+        gtin: null,
         category:
           products[0].categoryTree[products[0].categoryTree.length - 1].name,
         image: products[0].items[0].images[0].imageUrl,
@@ -84,6 +85,7 @@ describe('Product List Structured Data', () => {
           name: products[1].brand,
         },
         description: products[1].description,
+        gtin: null,
         category:
           products[1].categoryTree[products[1].categoryTree.length - 1].name,
         image: products[1].items[0].images[0].imageUrl,

--- a/react/package.json
+++ b/react/package.json
@@ -27,8 +27,9 @@
     "graphql": "^14.6.0",
     "schema-dts": "^0.8.2",
     "typescript": "3.9.7",
-    "vtex.apps-graphql": "3.17.4",
-    "vtex.render-runtime": "8.134.11"
+    "vtex.apps-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@3.17.4/public/@types/vtex.apps-graphql",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.134.11/public/@types/vtex.render-runtime",
+    "vtex.structured-data": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.12.1/public/@types/vtex.structured-data"
   },
   "version": "0.12.1"
 }

--- a/react/package.json
+++ b/react/package.json
@@ -27,8 +27,8 @@
     "graphql": "^14.6.0",
     "schema-dts": "^0.8.2",
     "typescript": "3.9.7",
-    "vtex.apps-graphql": "https://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@3.17.4/public/@types/vtex.apps-graphql",
-    "vtex.render-runtime": "https://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.134.11/public/@types/vtex.render-runtime"
+    "vtex.apps-graphql": "3.17.4",
+    "vtex.render-runtime": "8.134.11"
   },
   "version": "0.12.1"
 }

--- a/react/package.json
+++ b/react/package.json
@@ -26,7 +26,10 @@
     "apollo-cache-inmemory": "^1.6.5",
     "graphql": "^14.6.0",
     "schema-dts": "^0.8.2",
-    "typescript": "3.9.7"
+    "typescript": "3.9.7",
+    "vtex.apps-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@3.17.4/public/@types/vtex.apps-graphql",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.134.11/public/@types/vtex.render-runtime",
+    "vtex.structured-data": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.12.1/public/@types/vtex.structured-data"
   },
   "version": "0.12.1"
 }

--- a/react/package.json
+++ b/react/package.json
@@ -28,8 +28,7 @@
     "schema-dts": "^0.8.2",
     "typescript": "3.9.7",
     "vtex.apps-graphql": "https://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@3.17.4/public/@types/vtex.apps-graphql",
-    "vtex.render-runtime": "https://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.134.11/public/@types/vtex.render-runtime",
-    "vtex.structured-data": "https://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.12.1/public/@types/vtex.structured-data"
+    "vtex.render-runtime": "https://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.134.11/public/@types/vtex.render-runtime"
   },
   "version": "0.12.1"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5517,6 +5517,18 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+"vtex.apps-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@3.17.4/public/@types/vtex.apps-graphql":
+  version "3.17.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@3.17.4/public/@types/vtex.apps-graphql#0e0abc699713a7113f1ec4948456bcd9e330d0f9"
+
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.134.11/public/@types/vtex.render-runtime":
+  version "8.134.11"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.134.11/public/@types/vtex.render-runtime#0e42a00ac9b26c34b5b18b7a080f7dc3a5ac9959"
+
+"vtex.structured-data@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.12.1/public/@types/vtex.structured-data":
+  version "0.12.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.12.1/public/@types/vtex.structured-data#e16878cda359132ac26b5a83ed0123ec0cd486d5"
+
 w3c-hr-time@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5525,10 +5525,6 @@ verror@1.10.0:
   version "8.134.11"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.134.11/public/@types/vtex.render-runtime#0e42a00ac9b26c34b5b18b7a080f7dc3a5ac9959"
 
-"vtex.structured-data@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.12.1/public/@types/vtex.structured-data":
-  version "0.12.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.12.1/public/@types/vtex.structured-data#e16878cda359132ac26b5a83ed0123ec0cd486d5"
-
 w3c-hr-time@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5525,6 +5525,10 @@ verror@1.10.0:
   version "8.134.11"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.134.11/public/@types/vtex.render-runtime#0e42a00ac9b26c34b5b18b7a080f7dc3a5ac9959"
 
+"vtex.structured-data@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.12.1/public/@types/vtex.structured-data":
+  version "0.12.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.structured-data@0.12.1/public/@types/vtex.structured-data#e16878cda359132ac26b5a83ed0123ec0cd486d5"
+
 w3c-hr-time@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5517,13 +5517,13 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.apps-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@3.17.4/public/@types/vtex.apps-graphql":
+"vtex.apps-graphql@https://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@3.17.4/public/@types/vtex.apps-graphql":
   version "3.17.4"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@3.17.4/public/@types/vtex.apps-graphql#0e0abc699713a7113f1ec4948456bcd9e330d0f9"
+  resolved "https://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@3.17.4/public/@types/vtex.apps-graphql#0e0abc699713a7113f1ec4948456bcd9e330d0f9"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.134.11/public/@types/vtex.render-runtime":
+"vtex.render-runtime@https://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.134.11/public/@types/vtex.render-runtime":
   version "8.134.11"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.134.11/public/@types/vtex.render-runtime#0e42a00ac9b26c34b5b18b7a080f7dc3a5ac9959"
+  resolved "https://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.134.11/public/@types/vtex.render-runtime#0e42a00ac9b26c34b5b18b7a080f7dc3a5ac9959"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5517,14 +5517,6 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.apps-graphql@https://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@3.17.4/public/@types/vtex.apps-graphql":
-  version "3.17.4"
-  resolved "https://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@3.17.4/public/@types/vtex.apps-graphql#0e0abc699713a7113f1ec4948456bcd9e330d0f9"
-
-"vtex.render-runtime@https://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.134.11/public/@types/vtex.render-runtime":
-  version "8.134.11"
-  resolved "https://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.134.11/public/@types/vtex.render-runtime#0e42a00ac9b26c34b5b18b7a080f7dc3a5ac9959"
-
 w3c-hr-time@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5517,6 +5517,14 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+"vtex.apps-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@3.17.4/public/@types/vtex.apps-graphql":
+  version "3.17.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.apps-graphql@3.17.4/public/@types/vtex.apps-graphql#0e0abc699713a7113f1ec4948456bcd9e330d0f9"
+
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.134.11/public/@types/vtex.render-runtime":
+  version "8.134.11"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.134.11/public/@types/vtex.render-runtime#0e42a00ac9b26c34b5b18b7a080f7dc3a5ac9959"
+
 w3c-hr-time@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"


### PR DESCRIPTION
**What problem is this solving?**
Merchants submit their product feeds to Google Merchant Center, Google Shopping, and other channels. They use their internal product identifier as their product ID throughout these platforms. VTEX generates schema with our internal productId, which is meaningless to them. Google crawls the merchant’s site and cannot match the products submitted in the feed with the products on the site - mainly because Google relies on rich results to understand the product details, price, etc. 
Cosmo has experienced a drop and disapproval on their Google shopping campaigns for this and other reasons (like availability messaging). 
<!--- What is the motivation and context for this change? -->

**How should this be manually tested?**
This product should have FSAGFEN27410000 in the snippet. 

https://search.google.com/test/rich-results/result/r%2fproduct?id=fIjCgjuI4ycmPz01zo_E0w 

After the change
[https://wender--cosmo.myvtex.com/fender-tone-master-deluxe-reverb-combo-amp/p](https://wender--cosmo.myvtex.com/fender-tone-master-deluxe-reverb-combo-amp/p)
<img width="1237" alt="image" src="https://github.com/user-attachments/assets/206fa929-240f-453c-b90e-e4236e769207">

