### PR TITLE
New appSettings: disableAggregateOffer and useImagesArray

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,5 +3,14 @@
   "root": true,
   "env": {
     "node": true
+  },
+  "rules": {
+    "@typescript-eslint/camelcase": "off",
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,14 +3,5 @@
   "root": true,
   "env": {
     "node": true
-  },
-  "rules": {
-    "@typescript-eslint/camelcase": "off",
-    "prettier/prettier": [
-      "error",
-      {
-        "endOfLine": "auto"
-      }
-    ]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+Creatioj of 2 new appSettings (false by default):
+
+- disableAggregateOffer - used to change the aggregateOffer in Offer
+- useImagesArray - used to consider an array of images for the product, instead using only the first one
+
 ## [0.12.2] - 2024-10-16
 
 ### Changed
+
 - **Product Schema** for **Reference Number**, `mpn` now uses item reference identification.
 
 ### Added
+
 - `GTIN` when `EAN` is available
 
 ## [0.12.1] - 2024-06-17

--- a/manifest.json
+++ b/manifest.json
@@ -46,6 +46,18 @@
         "type": "boolean",
         "default": false,
         "description": "Use seller default price in AggregateOffer"
+      },
+      "disableAggregateOffer": {
+        "title": "Disable aggregate offer",
+        "type": "boolean",
+        "default": false,
+        "description": "Use single Offer insteand of AggregateOffer"
+      },
+      "useImagesArray": {
+        "title": "Use images array",
+        "type": "boolean",
+        "default": false,
+        "description": "Use images array for product instead of single one"
       }
     }
   },

--- a/react/Product.js
+++ b/react/Product.js
@@ -114,7 +114,7 @@ const getSellerDefault = (sellers) => {
 const composeAggregateOffer = (
   product,
   currency,
-  { decimals, pricesWithTax, useSellerDefault }
+  { decimals, pricesWithTax, useSellerDefault, disableAggregateOffer }
 ) => {
   const items = product.items || []
   const allSellers = getAllSellers(items)
@@ -132,6 +132,10 @@ const composeAggregateOffer = (
 
   if (offersList.length === 0) {
     return null
+  }
+
+  if (disableAggregateOffer) {
+    return offersList
   }
 
   const aggregateOffer = {
@@ -166,8 +170,10 @@ export const parseToJsonLD = ({
   decimals,
   pricesWithTax,
   useSellerDefault,
+  disableAggregateOffer,
+  useImagesArray,
 }) => {
-  const [image] = selectedItem ? selectedItem.images : []
+  const images = selectedItem ? selectedItem.images : []
   const { brand } = product
   const name = product.productName
 
@@ -180,6 +186,7 @@ export const parseToJsonLD = ({
     decimals,
     pricesWithTax,
     useSellerDefault,
+    disableAggregateOffer,
   })
 
   if (offers === null) {
@@ -198,7 +205,9 @@ export const parseToJsonLD = ({
     '@id': `${baseUrl}/${product.linkText}/p`,
     name,
     brand: parseBrand(brand),
-    image: image?.imageUrl || null,
+    image: useImagesArray
+      ? images.map((el) => el.imageUrl)
+      : images[0]?.imageUrl || null,
     description: product.metaTagDescription || product.description,
     mpn,
     sku: selectedItem?.itemId || null,
@@ -220,6 +229,8 @@ function StructuredData({ product, selectedItem }) {
     disableOffers,
     pricesWithTax,
     useSellerDefault,
+    useImagesArray,
+    disableAggregateOffer,
   } = useAppSettings()
 
   const productLD = parseToJsonLD({
@@ -230,6 +241,8 @@ function StructuredData({ product, selectedItem }) {
     decimals,
     pricesWithTax,
     useSellerDefault,
+    disableAggregateOffer,
+    useImagesArray,
   })
 
   return <script {...jsonLdScriptProps(productLD)} />

--- a/react/hooks/useAppSettings.ts
+++ b/react/hooks/useAppSettings.ts
@@ -19,7 +19,7 @@ interface Settings {
 }
 
 const useAppSettings = (): Settings => {
-  const { data } = useQuery(GET_SETTINGS, { ssr: false })
+  const { data } = useQuery(GET_SETTINGS, { ssr: true })
 
   if (data?.publicSettingsForApp?.message) {
     const {

--- a/react/hooks/useAppSettings.ts
+++ b/react/hooks/useAppSettings.ts
@@ -6,12 +6,16 @@ const DEFAULT_DISABLE_OFFERS = false
 const DEFAULT_DECIMALS = 2
 const DEFAULT_PRICES_WITH_TAX = false
 const DEFAULT_USE_SELLER_DEFAULT = false
+const DEFAULT_DISABLE_AGGREGATE_OFFER = false
+const DEFAULT_USE_IMAGES_ARRAY = false
 
 interface Settings {
   disableOffers: boolean
   decimals: number
   pricesWithTax: boolean
   useSellerDefault: boolean
+  disableAggregateOffer: boolean
+  useImagesArray: boolean
 }
 
 const useAppSettings = (): Settings => {
@@ -23,6 +27,8 @@ const useAppSettings = (): Settings => {
       disableOffers,
       pricesWithTax,
       useSellerDefault,
+      disableAggregateOffer,
+      useImagesArray,
     } = JSON.parse(data.publicSettingsForApp.message)
 
     return {
@@ -30,6 +36,9 @@ const useAppSettings = (): Settings => {
       decimals: decimals || DEFAULT_DECIMALS,
       pricesWithTax: pricesWithTax || DEFAULT_PRICES_WITH_TAX,
       useSellerDefault: useSellerDefault || DEFAULT_USE_SELLER_DEFAULT,
+      disableAggregateOffer:
+        disableAggregateOffer || DEFAULT_DISABLE_AGGREGATE_OFFER,
+      useImagesArray: useImagesArray || DEFAULT_USE_IMAGES_ARRAY,
     }
   }
 
@@ -38,6 +47,8 @@ const useAppSettings = (): Settings => {
     decimals: DEFAULT_DECIMALS,
     pricesWithTax: DEFAULT_PRICES_WITH_TAX,
     useSellerDefault: DEFAULT_USE_SELLER_DEFAULT,
+    disableAggregateOffer: DEFAULT_DISABLE_AGGREGATE_OFFER,
+    useImagesArray: DEFAULT_USE_IMAGES_ARRAY,
   }
 }
 


### PR DESCRIPTION
**What problem is this solving?**

This PR contains 2 new appSettings (false by default):

- disableAggregateOffer
- useImagesArray

The first one is used to change the aggregateOffer in Offer, with these benefits:

- Greater clarity for Google: By using the Offer field for simple products, Google can better understand product features, show them to the most relevant users and position them more relevantly in search results.
- Improved user experience: Clearer and more precise markup can lead to richer and more informative search results, making it easier for the user to choose.
- Increased CTR (Click-Through Rate): Better indexing and richer search results can lead to increased visibility of your site, a clearer and more relevant message is more likely to be clicked by users.
- Increased conversions: A higher CTR, combined with a good user experience on the website, can lead to increased sales.

The second one is used to consider an array of images for the product, instead using only the first one

**How should this be manually tested?**

These ws can be used:
https://www.whirlpool.it/microonde-da-incasso-whirlpool-colore-acciaio-inox-amw-730ix-858773001900/p?workspace=pdt1142
https://www.whirlpool.it/microonde-da-incasso-whirlpool-colore-acciaio-inox-amw-730ix-858773001900/p?workspace=pdt1142disabled (appSettings set to false)

**Screenshots or example usage:**

![image](https://github.com/user-attachments/assets/4c688cf4-fb68-4461-ab70-b9edd96cf31a)
