### PR TITLE
Feat/use images array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-Creatioj of 2 new appSettings (false by default):
-
-- disableAggregateOffer - used to change the aggregateOffer in Offer
-- useImagesArray - used to consider an array of images for the product, instead using only the first one
+Creation of new appSettings (false by default) `useImagesArray` - used to consider an array of images for the product, instead using only the first one
 
 ## [0.12.2] - 2024-10-16
 

--- a/manifest.json
+++ b/manifest.json
@@ -47,12 +47,6 @@
         "default": false,
         "description": "Use seller default price in AggregateOffer"
       },
-      "disableAggregateOffer": {
-        "title": "Disable aggregate offer",
-        "type": "boolean",
-        "default": false,
-        "description": "Use single Offer insteand of AggregateOffer"
-      },
       "useImagesArray": {
         "title": "Use images array",
         "type": "boolean",

--- a/react/Product.js
+++ b/react/Product.js
@@ -186,7 +186,7 @@ export const parseToJsonLD = ({
     decimals,
     pricesWithTax,
     useSellerDefault,
-    disableAggregateOffer
+    disableAggregateOffer,
   })
 
   if (offers === null) {
@@ -206,8 +206,8 @@ export const parseToJsonLD = ({
     name,
     brand: parseBrand(brand),
     image: useImagesArray
-    ? images.map((el) => el.imageUrl)
-    : images[0]?.imageUrl || null,
+      ? images.map((el) => el.imageUrl)
+      : images[0]?.imageUrl || null,
     description: product.metaTagDescription || product.description,
     mpn,
     sku: selectedItem?.itemId || null,

--- a/react/Product.js
+++ b/react/Product.js
@@ -114,7 +114,7 @@ const getSellerDefault = (sellers) => {
 const composeAggregateOffer = (
   product,
   currency,
-  { decimals, pricesWithTax, useSellerDefault, disableAggregateOffer }
+  { decimals, pricesWithTax, useSellerDefault }
 ) => {
   const items = product.items || []
   const allSellers = getAllSellers(items)
@@ -132,10 +132,6 @@ const composeAggregateOffer = (
 
   if (offersList.length === 0) {
     return null
-  }
-
-  if (disableAggregateOffer) {
-    return offersList
   }
 
   const aggregateOffer = {
@@ -170,7 +166,6 @@ export const parseToJsonLD = ({
   decimals,
   pricesWithTax,
   useSellerDefault,
-  disableAggregateOffer,
   useImagesArray,
 }) => {
   const images = selectedItem ? selectedItem.images : []
@@ -186,7 +181,6 @@ export const parseToJsonLD = ({
     decimals,
     pricesWithTax,
     useSellerDefault,
-    disableAggregateOffer,
   })
 
   if (offers === null) {
@@ -230,7 +224,6 @@ function StructuredData({ product, selectedItem }) {
     pricesWithTax,
     useSellerDefault,
     useImagesArray,
-    disableAggregateOffer,
   } = useAppSettings()
 
   const productLD = parseToJsonLD({
@@ -241,7 +234,6 @@ function StructuredData({ product, selectedItem }) {
     decimals,
     pricesWithTax,
     useSellerDefault,
-    disableAggregateOffer,
     useImagesArray,
   })
 

--- a/react/hooks/useAppSettings.ts
+++ b/react/hooks/useAppSettings.ts
@@ -6,7 +6,6 @@ const DEFAULT_DISABLE_OFFERS = false
 const DEFAULT_DECIMALS = 2
 const DEFAULT_PRICES_WITH_TAX = false
 const DEFAULT_USE_SELLER_DEFAULT = false
-const DEFAULT_DISABLE_AGGREGATE_OFFER = false
 const DEFAULT_USE_IMAGES_ARRAY = false
 
 interface Settings {

--- a/react/hooks/useAppSettings.ts
+++ b/react/hooks/useAppSettings.ts
@@ -14,7 +14,6 @@ interface Settings {
   decimals: number
   pricesWithTax: boolean
   useSellerDefault: boolean
-  disableAggregateOffer: boolean
   useImagesArray: boolean
 }
 
@@ -27,7 +26,6 @@ const useAppSettings = (): Settings => {
       disableOffers,
       pricesWithTax,
       useSellerDefault,
-      disableAggregateOffer,
       useImagesArray,
     } = JSON.parse(data.publicSettingsForApp.message)
 
@@ -36,8 +34,6 @@ const useAppSettings = (): Settings => {
       decimals: decimals || DEFAULT_DECIMALS,
       pricesWithTax: pricesWithTax || DEFAULT_PRICES_WITH_TAX,
       useSellerDefault: useSellerDefault || DEFAULT_USE_SELLER_DEFAULT,
-      disableAggregateOffer:
-        disableAggregateOffer || DEFAULT_DISABLE_AGGREGATE_OFFER,
       useImagesArray: useImagesArray || DEFAULT_USE_IMAGES_ARRAY,
     }
   }
@@ -47,7 +43,6 @@ const useAppSettings = (): Settings => {
     decimals: DEFAULT_DECIMALS,
     pricesWithTax: DEFAULT_PRICES_WITH_TAX,
     useSellerDefault: DEFAULT_USE_SELLER_DEFAULT,
-    disableAggregateOffer: DEFAULT_DISABLE_AGGREGATE_OFFER,
     useImagesArray: DEFAULT_USE_IMAGES_ARRAY,
   }
 }


### PR DESCRIPTION
**What problem is this solving?**

This PR contains a new appSetting (false by default):

useImagesArray

It is used to consider an array of images for the product, instead using only the first one

**How should this be manually tested?**

These ws can be used:
https://www.whirlpool.it/microonde-da-incasso-whirlpool-colore-acciaio-inox-amw-730ix-858773001900/p?workspace=pdt1142
https://www.whirlpool.it/microonde-da-incasso-whirlpool-colore-acciaio-inox-amw-730ix-858773001900/p?workspace=pdt1142disabled (appSettings set to false)

**Screenshots or example usage:**

![image](https://github.com/user-attachments/assets/5ae27c7c-ea56-478e-bd45-32e689fa1be0)
