### PR TITLE
upgrade `actions/cache` from v1 to v4

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: 'echo "::set-output name=dir::$(yarn cache dir)"'
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         id: yarn-cache
         with:
           path: '${{ steps.yarn-cache-dir-path.outputs.dir }}'
@@ -54,7 +54,7 @@ jobs:
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: 'echo "::set-output name=dir::$(yarn cache dir)"'
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         id: yarn-cache
         with:
           path: '${{ steps.yarn-cache-dir-path.outputs.dir }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Updated GitHub Actions configuration to use `actions/cache@v4` to avoid issues with deprecated versions (`v1` and `v2`), which will be retired on March 1st, 2025.
+
 ## [0.12.2] - 2024-10-16
 
 ### Changed


### PR DESCRIPTION
### What problem is this solving?

This PR updates the GitHub Actions configuration to use `actions/cache@v4`, as the previous versions (`v1` and `v2`) will be deprecated on March 1st, 2025. This ensures that the workflows continue to function without failure when the deprecated versions are shut down.

### How should this be manually tested?

1. Ensure that the repository is configured with the updated GitHub Actions workflow file.
2. Trigger a pull request to the `master` branch and check that the workflows (`Danger CI`, `IO app test`, and `Lint`) run without errors.
3. Verify that caching is functioning properly, especially for yarn dependencies, by checking the cache status in the GitHub Actions logs.

### Screenshots or example usage:

No visible changes, as this is a backend fix related to GitHub Actions workflow. You can verify the successful execution of the actions in the GitHub Actions logs for the respective jobs.