### PR TITLE
Add new setting select value from product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add new setting in app settings
+- Use this new setting value in Product JS
+
 ## [0.14.0] - 2025-03-11
 
 - Creation of new appSettings (false by default) `useImagesArray` - used to consider an array of images for the product, instead using only the first one

--- a/manifest.json
+++ b/manifest.json
@@ -58,6 +58,28 @@
         "type": "boolean",
         "default": false,
         "description": "Use single Offer insteand of AggregateOffer"
+      },
+      "gtinValue": {
+        "title": "GTIN Value",
+        "type": "string",
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": [
+              "ean"
+            ],
+            "title": "EAN"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "itemId"
+            ],
+            "title": "SKU ID"
+          }
+        ],
+        "default": "ean",
+        "description": "Set the value used for GTIN"
       }
     }
   },

--- a/react/Product.js
+++ b/react/Product.js
@@ -60,6 +60,16 @@ const OUT_OF_STOCK = 'http://schema.org/OutOfStock'
 const getSKUAvailabilityString = (seller) =>
   isSkuAvailable(seller) ? IN_STOCK : OUT_OF_STOCK
 
+const formatGTIN = (gtin) => {
+  if (!gtin || typeof gtin !== 'string') return null
+
+  const validLengths = [8, 12, 13, 14]
+  if (validLengths.includes(gtin.length)) return gtin
+
+  const targetLength = validLengths.find((len) => gtin.length < len) || 14
+  return gtin.padStart(targetLength, '0')
+}
+
 const parseSKUToOffer = (
   item,
   currency,
@@ -198,7 +208,8 @@ export const parseToJsonLD = ({
 
   const category = getCategoryName(product)
 
-  const gtin = selectedItem?.[gtinValue] || null
+  const rawGTIN = selectedItem?.[gtinValue] || null
+  const gtin = formatGTIN(rawGTIN)
 
   const productLD = {
     '@context': 'https://schema.org/',

--- a/react/Product.js
+++ b/react/Product.js
@@ -172,6 +172,7 @@ export const parseToJsonLD = ({
   useSellerDefault,
   useImagesArray,
   disableAggregateOffer,
+  gtinValue,
 }) => {
   const images = selectedItem ? selectedItem.images : []
   const { brand } = product
@@ -197,7 +198,7 @@ export const parseToJsonLD = ({
 
   const category = getCategoryName(product)
 
-  const gtin = selectedItem?.ean || null
+  const gtin = selectedItem?.[gtinValue]
 
   const productLD = {
     '@context': 'https://schema.org/',
@@ -231,6 +232,7 @@ function StructuredData({ product, selectedItem }) {
     useSellerDefault,
     useImagesArray,
     disableAggregateOffer,
+    gtinValue,
   } = useAppSettings()
 
   const productLD = parseToJsonLD({
@@ -243,6 +245,7 @@ function StructuredData({ product, selectedItem }) {
     useSellerDefault,
     useImagesArray,
     disableAggregateOffer,
+    gtinValue,
   })
 
   return <script {...jsonLdScriptProps(productLD)} />

--- a/react/Product.js
+++ b/react/Product.js
@@ -198,7 +198,7 @@ export const parseToJsonLD = ({
 
   const category = getCategoryName(product)
 
-  const gtin = selectedItem?.[gtinValue]
+  const gtin = selectedItem?.[gtinValue] || null
 
   const productLD = {
     '@context': 'https://schema.org/',

--- a/react/hooks/useAppSettings.ts
+++ b/react/hooks/useAppSettings.ts
@@ -8,6 +8,7 @@ const DEFAULT_PRICES_WITH_TAX = false
 const DEFAULT_USE_SELLER_DEFAULT = false
 const DEFAULT_USE_IMAGES_ARRAY = false
 const DEFAULT_DISABLE_AGGREGATE_OFFER = false
+const DEFAULT_GTIN_VALUE = 'ean'
 
 interface Settings {
   disableOffers: boolean
@@ -16,6 +17,7 @@ interface Settings {
   useSellerDefault: boolean
   useImagesArray: boolean
   disableAggregateOffer: boolean
+  gtinValue?: string
 }
 
 const useAppSettings = (): Settings => {
@@ -29,6 +31,7 @@ const useAppSettings = (): Settings => {
       useSellerDefault,
       useImagesArray,
       disableAggregateOffer,
+      gtinValue
     } = JSON.parse(data.publicSettingsForApp.message)
 
     return {
@@ -39,6 +42,7 @@ const useAppSettings = (): Settings => {
       useImagesArray: useImagesArray || DEFAULT_USE_IMAGES_ARRAY,
       disableAggregateOffer:
         disableAggregateOffer || DEFAULT_DISABLE_AGGREGATE_OFFER,
+      gtinValue: gtinValue || DEFAULT_GTIN_VALUE
     }
   }
 
@@ -49,6 +53,7 @@ const useAppSettings = (): Settings => {
     useSellerDefault: DEFAULT_USE_SELLER_DEFAULT,
     useImagesArray: DEFAULT_USE_IMAGES_ARRAY,
     disableAggregateOffer: DEFAULT_DISABLE_AGGREGATE_OFFER,
+    gtinValue: DEFAULT_GTIN_VALUE
   }
 }
 


### PR DESCRIPTION
## Description:
- For SEO purposes I want the schema.org to be updated on the PDP so that the GTIN Code is within the schema and that all the information is matching what we have within Google Merchant Centre, and we are synced for crawling purposes.

## Changes made:
- Added new setting with multiple dropdown values
- Using this setting in the `Product.js` to change value to one of the values

## Where to test?
- You can test [here](https://seo--dunnesstoresqa.myvtex.com/leigh-tucker-willow-bob-baby-jogger--3-months---3-years--5078291/p?skuId=24504)
- Inspect the page and search for `gtin`
- This value should change in the json block rendered on the frontend depending the value selected
- default value is ean

## Screenshots of changes:
![My Apps 2025-03-11 at 6 01 48 PM](https://github.com/user-attachments/assets/314d4582-ca96-4218-a161-8d3cde117210)

##### Using SKU ID value:
![Leigh Tucker Willow Bob Baby Jogger (3 months - 3 years) - Dunnes Stores 2025-03-11 at 6 02 15 PM](https://github.com/user-attachments/assets/b56ad99a-2591-4008-a218-88fa18e1ffe2)

##### Using EAN Value:
![Leigh Tucker Willow Bob Baby Jogger (3 months - 3 years) - Dunnes Stores 2025-03-11 at 6 04 04 PM](https://github.com/user-attachments/assets/b1ab6887-d998-4cee-af01-537c5699133c)
