### PR TITLE
feat: add disableProduct appSetting to disable Product JSON-LD enrich…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Creation of a new appSettings (false by default) `disableProduct` - used to disable the product enrichment in Product structured data (JSON-LD).
+
 ## [0.16.0] - 2025-07-18
 
 ## [0.15.0] - 2025-04-28

--- a/manifest.json
+++ b/manifest.json
@@ -80,6 +80,12 @@
         ],
         "default": "ean",
         "description": "Set the value used for GTIN"
+      },
+      "disableProduct": {
+        "title": "Disable Product",
+        "type": "boolean",
+        "default": false,
+        "description": "Disable product"
       }
     }
   },

--- a/react/Product.js
+++ b/react/Product.js
@@ -260,7 +260,12 @@ function StructuredData({ product, selectedItem }) {
     useImagesArray,
     disableAggregateOffer,
     gtinValue,
+    disableProduct
   } = useAppSettings()
+
+  if (disableProduct) {
+    return null;
+  }
 
   const productLD = parseToJsonLD({
     product,

--- a/react/hooks/useAppSettings.ts
+++ b/react/hooks/useAppSettings.ts
@@ -9,6 +9,7 @@ const DEFAULT_USE_SELLER_DEFAULT = false
 const DEFAULT_USE_IMAGES_ARRAY = false
 const DEFAULT_DISABLE_AGGREGATE_OFFER = false
 const DEFAULT_GTIN_VALUE = 'itemId'
+const DEFAULT_DISABLE_PRODUCT = false
 
 interface Settings {
   disableOffers: boolean
@@ -17,7 +18,8 @@ interface Settings {
   useSellerDefault: boolean
   useImagesArray: boolean
   disableAggregateOffer: boolean
-  gtinValue?: string
+  gtinValue?: string,
+  disableProduct?: boolean
 }
 
 const useAppSettings = (): Settings => {
@@ -32,6 +34,7 @@ const useAppSettings = (): Settings => {
       useImagesArray,
       disableAggregateOffer,
       gtinValue,
+      disableProduct
     } = JSON.parse(data.publicSettingsForApp.message)
 
     return {
@@ -43,6 +46,7 @@ const useAppSettings = (): Settings => {
       disableAggregateOffer:
         disableAggregateOffer || DEFAULT_DISABLE_AGGREGATE_OFFER,
       gtinValue: gtinValue || DEFAULT_GTIN_VALUE,
+      disableProduct: disableProduct || DEFAULT_DISABLE_PRODUCT,
     }
   }
 
@@ -54,6 +58,7 @@ const useAppSettings = (): Settings => {
     useImagesArray: DEFAULT_USE_IMAGES_ARRAY,
     disableAggregateOffer: DEFAULT_DISABLE_AGGREGATE_OFFER,
     gtinValue: DEFAULT_GTIN_VALUE,
+    disableProduct: DEFAULT_DISABLE_PRODUCT,
   }
 }
 


### PR DESCRIPTION
**What problem is this solving?**

Some merchants need to disable product structured data enrichment (`Product JSON-LD`) due to duplicated information or custom SEO strategies.  
This PR introduces a new appSetting `disableProduct` (default: false) that allows disabling product enrichment.  

**How should this be manually tested?**

- You can test it [Here](https://cucardasv2enrichment--jumboargentinaio.myvtex.com/galletitas-rellenas-con-crema-sabor-original-354-gr-x-3-un-oreo-2/p)

## How to test
1. Go to **Admin > Apps > Installed apps**.
2. Configure `disableProduct = true`.
3. Check product pages → JSON-LD enrichment should be disabled.
4. Configure `disableProduct = false`.
5. Check product pages → JSON-LD enrichment should appear again.

**Screenshots or example usage:**

`vtex admin disableProduct in structured-data`  
<img width="833" height="843" alt="Screenshot 2025-09-18 at 10 43 54 a.m." src="https://github.com/user-attachments/assets/df5acd5f-03d7-4092-9a0d-b41aaeaa0481" />

Product inspection: we searched for the native product schema and couldn’t find it.  

<img width="1565" height="405" alt="Screenshot 2025-09-18 at 10 41 13 a.m." src="https://github.com/user-attachments/assets/647165ea-1dc0-4ea9-97ce-127ab81423fd" />
