### PR TITLE
chore: STR-969 catalog platform-flow-id (Shopper#1)

### DIFF
--- a/.vtex/catalog-info.yaml
+++ b/.vtex/catalog-info.yaml
@@ -13,7 +13,7 @@ metadata:
     vtex.com/o11y-os-index: ""
     grafana/dashboard-selector: ""
     github.com/project-slug: vtex-apps/structured-data
-    vtex.com/platform-flow-id: ""
+    vtex.com/platform-flow-id: Shopper#1
     backstage.io/techdocs-ref: dir:../
     vtex.com/application-id: 6KRT3AL4
 spec:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Update DK Catalog platform-flow-id
+
 ## [0.17.0] - 2026-03-11
 
 ### Added


### PR DESCRIPTION
## Jira

https://vtex-dev.atlassian.net/browse/STR-969

## Summary

Updates Backstage catalog metadata by setting `vtex.com/platform-flow-id` in `.vtex/catalog-info.yaml` to match the **Platform Flows (Dark Kitchen)** classification for this component (initiative STR-969).

## Change

| Annotation | Value |
|------------|-------|
| `vtex.com/platform-flow-id` | `Shopper#1` |

**Convention:** multiple DK IDs are **comma-separated with no spaces**.

## Classification context (source artifact)

The following summary is taken from the internal classification table (Portuguese) used for STR-969:

> **App:** JSON-LD Schema.org (SEO). **Decisão:** README: rich results para produtos → descoberta orgânica (**Shopper#1**).

## Changelog

- `CHANGELOG.md` — **[Unreleased]** → **Changed**: Update DK Catalog platform-flow-id


---

Reviewers: @vmourac-vtex @iago1501
